### PR TITLE
Feature: Add images fetch logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ Add an asset to a new cache via DevTools:
 .then(() => console.log('Success!'))
 .catch(() => console.log('Sorry, it failed.'));
 ```
+
+## Caching Strategies
+
+Cache Only and Network Only aren't typical use cases. Cache First covers both.
+
+- [Cache Only](https://jakearchibald.com/2014/offline-cookbook/#cache-only)
+- [Network Only](https://jakearchibald.com/2014/offline-cookbook/#network-only)
+- [Cache First (Cache Falling Back to Network)](https://jakearchibald.com/2014/offline-cookbook/#cache-falling-back-to-network)
+- [Network First (Network Falling Back to Cache)](https://jakearchibald.com/2014/offline-cookbook/#network-falling-back-to-cache)
+- [Stale-While-Revalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate)

--- a/README.md
+++ b/README.md
@@ -8,10 +8,27 @@ Add an asset to a new cache via DevTools:
 ```js
 (async function() {
   const cache = await caches.open('my-cache');
-  await cache.addAll(['/images/portland.svg']);
+  await cache.add('/images/portland.svg');
 }())
-.then(() => console.log('Success!'))
-.catch(() => console.log('Sorry, it failed.'));
+```
+```js
+caches.open('my-cache')
+  .then(cache => cache.add('/images/portland.svg'));
+```
+With "success"/"fail" logs:
+```js
+(async function() {
+  const cache = await caches.open('my-cache');
+  await cache.add('/images/portland.svg');
+}())
+  .then(() => console.log('Success!'))
+  .catch(() => console.log('Sorry, it failed.'));
+```
+```js
+caches.open('my-cache')
+  .then(cache => cache.add('/images/portland.svg'))
+  .then(() => console.log('Success!'))
+  .catch(() => console.log('Sorry, it failed.'));
 ```
 
 ## Caching Strategies
@@ -23,3 +40,5 @@ Cache Only and Network Only aren't typical use cases. Cache First covers both.
 - [Cache First (Cache Falling Back to Network)](https://jakearchibald.com/2014/offline-cookbook/#cache-falling-back-to-network)
 - [Network First (Network Falling Back to Cache)](https://jakearchibald.com/2014/offline-cookbook/#network-falling-back-to-cache)
 - [Stale-While-Revalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate)
+
+- [Timing out](https://adactio.com/journal/15122)

--- a/service-worker.js
+++ b/service-worker.js
@@ -18,9 +18,15 @@ const PWA_WORKSHOP = 'pwa-workshop';
  * Edit the `GLOBAL_VERSION` to delete all caches.
  * Edit the individual cache version to delete a specific cache.
  */
-const GLOBAL_VERSION = 2;
+const GLOBAL_VERSION = 1;
 const STATIC_ASSETS_CACHE = `${PWA_WORKSHOP}-static-assets-v${GLOBAL_VERSION + 0}`;
 const RUNTIME_CACHE = `${PWA_WORKSHOP}-runtime-v${GLOBAL_VERSION + 0}`;
+
+// Store the most current cache names. Helps to delete out-of-date caches.
+const EXPECTED_CACHES = [
+  STATIC_ASSETS_CACHE,
+  RUNTIME_CACHE
+];
 
 const MUST_HAVE_STATIC_ASSETS = [
   '/css/styles.css',
@@ -41,8 +47,6 @@ self.addEventListener('install', event => {
   console.group('Service Worker `install` Event')
 
   event.waitUntil(async function() {
-    console.log(`Attempting to add assets to the "${STATIC_ASSETS_CACHE}" cache...`);
-
     // Open the cache.
     const cache = await caches.open(STATIC_ASSETS_CACHE);
 
@@ -73,12 +77,12 @@ self.addEventListener('activate', event => {
     await Promise.all(
       /**
        * Filter for the caches we want to delete.
-       * We want to make sure it's a cache we added first.
-       * Then check against the current cache version.
+       * 1. Does the cache start with `pwa-workshop`?
+       * 2. Is it not included in the `EXPECTED_CACHES` array.
        */
       cacheNames.filter(cacheName => {
         return /^pwa-workshop/.test(cacheName) 
-          && cacheName !== STATIC_ASSETS_CACHE;
+          && !EXPECTED_CACHES.includes(cacheName);
       }).map(cacheName => {
         console.log(`Deleting cache "${cacheName}"`);
         return caches.delete(cacheName);


### PR DESCRIPTION
## Overview

This PR introduces the `fetch` logic for images using the [Stale-While-Revalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate) strategy.

A default catch-all [Cache-First (Cache, falling back to network)](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#cache-falling-back-to-network) strategy was also added.

## Testing

1. Checkout and run this branch locally:
    ```
    git checkout feature/fetch-logic && python -m SimpleHTTPServer
    ```

1. Open an incognito browser window in Chrome and open the **Network** tab _before_ loading the page

1. Paste in: `http://localhost:8000/page-template.html` and hit `Enter` to load the page

1. Confirm:
    - the assets load from the network initially
    - the SW fetches the `PRECACHE_ASSETS` list and stores them in cache
    <img width="1517" alt="Screen Shot 2019-05-27 at 10 33 04 PM" src="https://user-images.githubusercontent.com/459757/58453365-aff27980-80cf-11e9-8fb4-da0a7292ac6e.png">

    ![Screen Shot 2019-05-27 at 10 35 23 PM](https://user-images.githubusercontent.com/459757/58453427-f0ea8e00-80cf-11e9-8818-1a3666fe5c3c.png)

1. Refresh the page and confirm:
    - All assets except for the HTML document, `register-service-worker.js` and `portland.svg` are loaded from the service worker
    <img width="1517" alt="Screen Shot 2019-05-27 at 10 39 42 PM" src="https://user-images.githubusercontent.com/459757/58453538-635b6e00-80d0-11e9-9632-80703d53feb2.png">
    
    - Confirm an `pwa-workshop-images-v1` cache was created and the `portland.svg` file added
    <img width="1517" alt="Screen Shot 2019-05-27 at 10 40 50 PM" src="https://user-images.githubusercontent.com/459757/58453604-9aca1a80-80d0-11e9-9d26-d36a62669a4a.png">

1. Refresh once more and confirm the `portland.svg` file is now served from the service worker:
    <img width="1517" alt="Screen Shot 2019-05-27 at 10 45 25 PM" src="https://user-images.githubusercontent.com/459757/58453781-3196d700-80d1-11e9-8744-20a8e2801a37.png">


---

- [Trello Card](https://trello.com/c/ZzRHgIMc/5-service-worker-write-images-fetch-logic)