### PR TITLE
Feature: Refactor to add staleWhileRevalidate function + custom logging styles

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -110,8 +110,8 @@ const isImageRequest = request => IMAGE_REGEX.test(request.url);
 const logInfo = ({ heading, fetchType, url }) => {
   const headingStyles = [
     'font-weight: bold',
-    'background: green',
-    'border: 1px solid green',
+    'background: #456bd9',
+    'border: 1px solid #456bd9',
     'color: white',
     'padding: .6em'
   ].join(';');
@@ -126,7 +126,7 @@ const logInfo = ({ heading, fetchType, url }) => {
   ].join(';');
 
   console.info(
-    `%c(${heading})%c${fetchType} Fetch%c${url}`, 
+    `%c${heading}%cFrom ${fetchType}%c${url}`, 
     headingStyles, 
     fetchTypeStyles, 
     urlStyles
@@ -191,11 +191,13 @@ self.addEventListener('fetch', event => {
    */
   event.respondWith(async function() {
     const cachedResponse = await caches.match(request);
+
     if (cachedResponse) {
-      console.info('(Fallback) Cache Fetch:', request.url);
+      logInfo({ heading: 'Fallback', fetchType: 'Cache', url: request.url });
       return cachedResponse;
     }
-    console.info('(Fallback) Network Fetch:', request.url);
+
+    logInfo({ heading: 'Fallback', fetchType: 'Network', url: request.url });
     return fetch(request);
 }());
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -10,6 +10,7 @@
 const GLOBAL_VERSION = 1;
 const PWA_WORKSHOP = 'pwa-workshop';
 const CACHES = {
+  PWA_WORKSHOP: `${PWA_WORKSHOP}-v${GLOBAL_VERSION + 0}`,
   PRECACHED_ASSETS: `${PWA_WORKSHOP}-precached-assets-v${GLOBAL_VERSION + 0}`,
   IMAGES: `${PWA_WORKSHOP}-images-v${GLOBAL_VERSION + 0}`,
   RUNTIME: `${PWA_WORKSHOP}-runtime-v${GLOBAL_VERSION + 0}`
@@ -46,7 +47,7 @@ self.addEventListener('install', event => {
 
   event.waitUntil(async function() {
     // Open the cache.
-    const cache = await caches.open(CACHES.PRECACHED_ASSETS);
+    const cache = await caches.open(CACHES.PWA_WORKSHOP);
 
     // Install will not stop if one of these assets fails to cache.
     cache.addAll(PRECACHE_ASSETS.NICE_TO_HAVE)
@@ -99,6 +100,69 @@ self.addEventListener('activate', event => {
 const isImageRequest = request => IMAGE_REGEX.test(request.url);
 
 /**
+ * Helper to provide a custom styled console.info message
+ * 
+ * @param {Object} obj
+ * @param {string} obj.heading The heading (title) to log
+ * @param {string} obj.fetchType The message fetch type (Cache/Network)
+ * @param {string} obj.url The URL of the fetch
+ */
+const logInfo = ({ heading, fetchType, url }) => {
+  const headingStyles = [
+    'font-weight: bold',
+    'background: green',
+    'border: 1px solid green',
+    'color: white',
+    'padding: .6em'
+  ].join(';');
+  const fetchTypeStyles = [
+    'font-weight: normal',
+    'border: 1px dotted gray',
+    'padding: .6em'
+  ].join(';');
+  const urlStyles = [
+    'font-weight: normal',
+    'padding: .6em'
+  ].join(';');
+
+  console.info(
+    `%c(${heading})%c${fetchType} Fetch%c${url}`, 
+    headingStyles, 
+    fetchTypeStyles, 
+    urlStyles
+  );
+}
+
+/**
+ * Helper for the Stale-While-Revalidate caching strategy
+ * 
+ * @see https://jakearchibald.com/2014/offline-cookbook/#stale-while-revalidate
+ * 
+ * @param {FetchEvent} event A fetch event object
+ * @returns {Promise} Resolves to a fetch Response object
+ */
+const staleWhileRevalidate = async event => {
+  const { request } = event;
+
+  const cache = await caches.open(CACHES.PWA_WORKSHOP);
+  const cachedResponse = await cache.match(request);
+  const networkResponsePromise = fetch(request);
+
+  event.waitUntil(async function() {
+    const networkResponse = await networkResponsePromise;
+    cache.put(request, networkResponse.clone())
+  }());
+
+  if (cachedResponse) {
+    logInfo({ heading: 'Stale-While-Revalidate', fetchType: 'Cache', url: request.url });
+    return cachedResponse;
+  }
+
+  logInfo({ heading: 'Stale-While-Revalidate', fetchType: 'Network', url: request.url });
+  return networkResponsePromise;
+};
+
+/**
  * Handle the `fetch` service worker event.
  */
 self.addEventListener('fetch', event => {
@@ -108,27 +172,13 @@ self.addEventListener('fetch', event => {
   // Local URLs
   if (requestURL.origin === location.origin) {
     /**
-     * Images
-     * Stale-While-Revalidate
+     * Handle images
      */
     if (isImageRequest(request)) {
-      event.respondWith(async function() {
-        const cachedImage = await caches.match(request);
-        if (cachedImage) {
-          console.info('Cache Fetch:', request.url);
-          return cachedImage;
-        }
-        
-        const networkImage = await fetch(request);
-        const imagesCache = await caches.open(CACHES.IMAGES);
-        event.waitUntil(
-          imagesCache.put(request, networkImage.clone())
-        );
-
-        console.info('Network Fetch:', request.url);
-        return networkImage;
-      }());
-      // Exit 
+      event.respondWith(
+        staleWhileRevalidate(event)
+      );
+      // Exit, no need to continue `fetch` handler logic
       return;
     }
   }
@@ -142,10 +192,10 @@ self.addEventListener('fetch', event => {
   event.respondWith(async function() {
     const cachedResponse = await caches.match(request);
     if (cachedResponse) {
-      console.info('Cache Fetch:', request.url);
+      console.info('(Fallback) Cache Fetch:', request.url);
       return cachedResponse;
     }
-    console.info('Network Fetch:', request.url);
+    console.info('(Fallback) Network Fetch:', request.url);
     return fetch(request);
 }());
 });


### PR DESCRIPTION
## Overview

This PR refactors the **Stale-While-Revalidate** logic into a `staleWhileRevalidate()` function.

I also introduced custom log styling to help more clearly understand what strategy was used by the fetch request and where the response came from (cache vs network). 

## Screenshots

<img width="1005" alt="Screen Shot 2019-05-29 at 8 33 05 AM" src="https://user-images.githubusercontent.com/459757/58570363-b591b180-81ec-11e9-940c-16cf620b7df7.png">

---

/CC @grigs 
