### PR TITLE
Feature: Exercise 5, remove old caches

### DIFF
--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -144,9 +144,7 @@ self.addEventListener('activate', activateEvent => {
     // Each cache `delete()` will return a promise, 
     // so we need to await them all using `Promise.all`
     await Promise.all(
-      // Filter for the caches we want to delete:
-      // 1. The name should start with `pwa-workshop`
-      // 2. It should not be the current cache
+      // Filter for the caches we want to delete
       cacheNames.filter(cacheName => {
         return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
           && cacheName !== PWA_WORKSHOP_CACHE;

--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -1,0 +1,209 @@
+/**
+ * ------------------------
+ * Configuration constants
+ * ------------------------
+ */
+
+/**
+ * The name of the cache to store assets
+ */
+const VERSION = '1';
+const PWA_WORKSHOP_PREFIX = 'pwa-workshop-v';
+const PWA_WORKSHOP_CACHE = `${PWA_WORKSHOP_PREFIX}${VERSION}`;
+
+/**
+ * The list of assets to precache
+ * 
+ * `MUST_HAVE`: The service worker will not complete install if 
+ * these assets are not precached successfully.
+ * `NICE_TO_HAVE`: The service worker will continue even if these
+ * assets are not successfully precached.
+ */
+const PRECACHE_ASSETS = {
+  MUST_HAVE: [
+    '/css/styles.css',
+    '/fonts/source-code-pro-v6-latin-regular.woff2',
+    '/fonts/source-sans-pro-v9-latin-700.woff2',
+    '/fonts/source-sans-pro-v9-latin_latin-ext-italic.woff2',
+    '/fonts/source-sans-pro-v9-latin_latin-ext-regular.woff2',
+    '/fonts/source-sans-pro-v9-subset-600.woff',
+    '/scripts/main.js',
+    '/offline.html',
+    '/images/fallback.svg'
+  ],
+  NICE_TO_HAVE: [
+    '/images/portland.svg',
+    '/images/sky-friendly-robot.svg'
+  ]
+};
+
+/**
+ * ---------------------------
+ * Caching strategy functions
+ * ---------------------------
+ */
+
+/**
+ * "Cache First" caching strategy
+ * 
+ * 1. Fetch from the cache
+ *    - Return cached response if found
+ * 2. Fallback to fetch from the network
+ *    - Store a copy of the network response in the cache
+ *    - Return network response
+ * 
+ * @see https://jakearchibald.com/2014/offline-cookbook/#on-network-response
+ * @param {FetchEvent} fetchEvent A fetch event object
+ * @returns {Promise} Resolves to a fetch Response object
+ */
+const cacheFirst = async fetchEvent => {
+  const request = fetchEvent.request;
+  // Open our cache and look for a cached response
+  const cache = await caches.open(PWA_WORKSHOP_CACHE);
+  const cachedResponse = await cache.match(request);
+  if (cachedResponse) {
+    console.log(`Fetch from cache: ${request.url}`);
+    return cachedResponse;
+  }
+  // Otherwise, fetch from the network and store a copy in cache
+  const networkResponse = await fetch(request);
+  fetchEvent.waitUntil(
+    cache.put(request, networkResponse.clone())
+  );
+  // Finally return the network response
+  console.log(`Fetch from network: ${request.url}`);
+  return networkResponse;
+};
+
+/**
+ * "Cache, falling back to network" caching strategy
+ * 
+ * 1. Fetch from the cache
+ *    - Return cached response if found
+ * 2. Fallback to fetch from the network
+ *    - Return network response
+ * 
+ * @see https://jakearchibald.com/2014/offline-cookbook/#cache-falling-back-to-network
+ * @param {FetchEvent} fetchEvent A fetch event object
+ * @returns {Promise} Resolves to a fetch Response object
+ */
+const cacheFallingBackToNetwork = async fetchEvent => {
+  const request = fetchEvent.request;
+  // Look for the request in the caches
+  const cachedResponse = await caches.match(request);
+  // If found, return the cached response
+  if (cachedResponse) {
+    console.log(`Fetch from cache: ${request.url}`);
+    return cachedResponse;
+  }
+  // Otherwise, fetch from the network
+  console.log(`Fetch from network: ${request.url}`);
+  return fetch(request);
+};
+
+/**
+ * ------------------------------------------
+ * Service worker event listeners & handlers
+ * ------------------------------------------
+ */
+
+/**
+ * Listen for the `install` event
+ * 
+ * The `install` event is an ideal time to cache 
+ * CSS, JS, image and font static assets.
+ */
+self.addEventListener('install', installEvent => {
+  console.group('Service Worker `install` Event');
+
+  installEvent.waitUntil(async function() {
+    const cache = await caches.open(PWA_WORKSHOP_CACHE);
+
+    // Nice to have assets: Install will succeed if one of these assets fails to cache
+    cache.addAll(PRECACHE_ASSETS.NICE_TO_HAVE)
+      .then(() => console.log('Optional assets successfully cached!'))
+      .catch(error => console.warn('Optional assets failed to cache:', error));
+
+    // Required assets: Install will fail if one of these assets fails to cache
+    await cache.addAll(PRECACHE_ASSETS.MUST_HAVE)
+      .then(() => console.log('Required assets successfully cached!'))
+      .catch(error => console.warn('Required assets failed to cache:', error));
+
+    console.groupEnd();
+  }());
+});
+
+/**
+ * Listen for the `activate` event
+ */
+self.addEventListener('activate', activateEvent => {
+  console.group('Service Worker `activate` Event');
+  activateEvent.waitUntil(async function() {
+    // Get the names of all the existing caches
+    const cacheNames = await caches.keys();
+    // Each cache `delete()` will return a promise, 
+    // so we need to await them all using `Promise.all`
+    await Promise.all(
+      // Filter for the caches we want to delete:
+      // 1. The name should start with `pwa-workshop`
+      // 2. It should not be the current cache
+      cacheNames.filter(cacheName => {
+        return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
+          && cacheName !== PWA_WORKSHOP_CACHE;
+      }).map(cacheName => {
+        console.log(`Deleting cache "${cacheName}"`);
+        return caches.delete(cacheName);
+      })
+    );
+    console.groupEnd();
+  }());
+});
+
+/**
+ * Listen for the `fetch` event
+ * 
+ * @see https://medium.com/dev-channel/service-worker-caching-strategies-based-on-request-types-57411dd7652c
+ * @see https://jakearchibald.com/2014/offline-cookbook/#putting-it-together
+ */
+self.addEventListener('fetch', fetchEvent => {
+  const destination = fetchEvent.request.destination;
+  const requestURL = new URL(fetchEvent.request.url);
+  // Special handling for same-origin URLs only
+  if (requestURL.origin === location.origin) {
+    switch (destination) {
+      case 'document': {
+        fetchEvent.respondWith(
+          cacheFirst(fetchEvent)
+            .catch(error => caches.match('/offline.html'))
+        )
+        return;
+      }
+      case 'image': {
+        fetchEvent.respondWith(
+          cacheFirst(fetchEvent)
+            .catch(error => caches.match('/images/fallback.svg'))
+        );
+        return;
+      }
+      case 'style':
+      case 'script': {
+        fetchEvent.respondWith(
+          cacheFirst(fetchEvent)
+        )
+        return;
+      }
+      // If an `XMLHttpRequest` or `fetch()` from the document, the
+      // `Request.destination` is an empty string, use default strategy
+      default: {
+        fetchEvent.respondWith(
+          cacheFallingBackToNetwork(fetchEvent)
+        );
+        return;
+      }
+    }
+  }
+  // A good overall default
+  fetchEvent.respondWith(
+    cacheFallingBackToNetwork(fetchEvent)
+  );
+});

--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -144,14 +144,15 @@ self.addEventListener('activate', activateEvent => {
     // Each cache `delete()` will return a promise, 
     // so we need to await them all using `Promise.all`
     await Promise.all(
-      // Filter for the caches we want to delete
-      cacheNames.filter(cacheName => {
-        return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
-          && cacheName !== PWA_WORKSHOP_CACHE;
-      }).map(cacheName => {
-        console.log(`Deleting cache "${cacheName}"`);
-        return caches.delete(cacheName);
-      })
+      cacheNames
+        // Filter for the caches we want to delete
+        .filter(cacheName => cacheName.startsWith(PWA_WORKSHOP_PREFIX)
+          && cacheName !== PWA_WORKSHOP_CACHE)
+        // Then delete them
+        .map(cacheName => {
+          console.log(`Deleting cache "${cacheName}"`);
+          return caches.delete(cacheName);
+        })
     );
     console.groupEnd();
   }());

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,7 +7,9 @@
 /**
  * The name of the cache to store assets
  */
-const PWA_WORKSHOP_CACHE = `pwa-workshop-v1`;
+const VERSION = '1';
+const PWA_WORKSHOP_PREFIX = 'pwa-workshop-v';
+const PWA_WORKSHOP_CACHE = `${PWA_WORKSHOP_PREFIX}${VERSION}`;
 
 /**
  * The list of assets to precache
@@ -146,7 +148,7 @@ self.addEventListener('activate', activateEvent => {
       // 1. The name should start with `pwa-workshop`
       // 2. It should not be the current cache
       cacheNames.filter(cacheName => {
-        return /^pwa-workshop/.test(cacheName) 
+        return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
           && cacheName !== PWA_WORKSHOP_CACHE;
       }).map(cacheName => {
         console.log(`Deleting cache "${cacheName}"`);

--- a/service-worker.js
+++ b/service-worker.js
@@ -136,7 +136,6 @@ self.addEventListener('install', installEvent => {
  */
 self.addEventListener('activate', activateEvent => {
   console.group('Service Worker `activate` Event');
-
   activateEvent.waitUntil(async function() {
     // Get the names of all the existing caches
     const cacheNames = await caches.keys();
@@ -154,7 +153,6 @@ self.addEventListener('activate', activateEvent => {
         return caches.delete(cacheName);
       })
     );
-
     console.groupEnd();
   }());
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -135,7 +135,28 @@ self.addEventListener('install', installEvent => {
  * Listen for the `activate` event
  */
 self.addEventListener('activate', activateEvent => {
-  console.log('Activated');
+  console.group('Service Worker `activate` Event');
+
+  activateEvent.waitUntil(async function() {
+    // Get the names of all the existing caches
+    const cacheNames = await caches.keys();
+    // Each cache `delete()` will return a promise, 
+    // so we need to await them all using `Promise.all`
+    await Promise.all(
+      // Filter for the caches we want to delete:
+      // 1. The name should start with `pwa-workshop`
+      // 2. It should not be the current cache
+      cacheNames.filter(cacheName => {
+        return /^pwa-workshop/.test(cacheName) 
+          && cacheName !== PWA_WORKSHOP_CACHE;
+      }).map(cacheName => {
+        console.log(`Deleting cache "${cacheName}"`);
+        return caches.delete(cacheName);
+      })
+    );
+
+    console.groupEnd();
+  }());
 });
 
 /**

--- a/service-worker.js
+++ b/service-worker.js
@@ -144,9 +144,7 @@ self.addEventListener('activate', activateEvent => {
     // Each cache `delete()` will return a promise, 
     // so we need to await them all using `Promise.all`
     await Promise.all(
-      // Filter for the caches we want to delete:
-      // 1. The name should start with `pwa-workshop`
-      // 2. It should not be the current cache
+      // Filter for the caches we want to delete
       cacheNames.filter(cacheName => {
         return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
           && cacheName !== PWA_WORKSHOP_CACHE;

--- a/service-worker.js
+++ b/service-worker.js
@@ -144,14 +144,15 @@ self.addEventListener('activate', activateEvent => {
     // Each cache `delete()` will return a promise, 
     // so we need to await them all using `Promise.all`
     await Promise.all(
-      // Filter for the caches we want to delete
-      cacheNames.filter(cacheName => {
-        return cacheName.startsWith(PWA_WORKSHOP_PREFIX)
-          && cacheName !== PWA_WORKSHOP_CACHE;
-      }).map(cacheName => {
-        console.log(`Deleting cache "${cacheName}"`);
-        return caches.delete(cacheName);
-      })
+      cacheNames
+        // Filter for the caches we want to delete
+        .filter(cacheName => cacheName.startsWith(PWA_WORKSHOP_PREFIX)
+          && cacheName !== PWA_WORKSHOP_CACHE)
+        // Then delete them
+        .map(cacheName => {
+          console.log(`Deleting cache "${cacheName}"`);
+          return caches.delete(cacheName);
+        })
     );
     console.groupEnd();
   }());


### PR DESCRIPTION
## Overview

This PR introduces the logic to delete old caches during the service worker `activate` event.

## Screenshots

<img width="768" alt="Screen Shot 2019-06-01 at 6 21 45 PM" src="https://user-images.githubusercontent.com/459757/58755593-bac85800-849b-11e9-9e60-71f61c30b058.png">

## Testing

### Through the browser only

1. Load up https://deploy-preview-19--festive-keller-9a29cb.netlify.com/page-1.html and confirm the current version of the site cache (e.g. `pwa-workshop-v1`)

1. Add other caches manually via the browser console
    - add at least one that starts with the `pwa-workshop-*` prefix:

        ```
        caches.open('pwa-workshop-v4').then(cache => cache.add('/images/portland.svg'))
        ```
    - add at least one that _does not_ start with the `pwa-workshop-*` prefix:

        ```
        caches.open('non-pwa-workshop-cache').then(cache => cache.add('/images/portland.svg'))
        ```
    ![add-cache](https://user-images.githubusercontent.com/459757/58755734-98840980-849e-11e9-847e-5ccb047f08c7.gif)

1. Unregister the active service worker

    ![unregister-sw](https://user-images.githubusercontent.com/459757/58755750-03cddb80-849f-11e9-8ed7-3261271b6d77.gif)

1. Reload the page so the service worker can `install` and `activate`, confirm during the `activate` phase:
    - the caches you added beginning with the `pwa-workshop-*` prefix are deleted
    - caches not prefixed with `pwa-workshop-*` are _not_ deleted

        ![activate-phase-delete](https://user-images.githubusercontent.com/459757/58755766-56a79300-849f-11e9-922e-df40c85a8f1f.gif)

### Editing the service worker locally

1. Checkout the branch and run it on localhost:
    ```
    git checkout feature/exercise-5/delete-old-caches && python -m SimpleHTTPServer
    ```

1. Open http://localhost:8000/page-1.html

1. Confirm the `pwa-workshop-v1` cache exists in the **Application** > **Cache Storage** panel

1. Edit the `service-worker.js` file by changing the cache name version:
    ```diff
     /**
      * The name of the cache to store assets
      */
    -const PWA_WORKSHOP_CACHE = `pwa-workshop-v1`;
    +const PWA_WORKSHOP_CACHE = `pwa-workshop-v2`;
    ```

1. After saving the `service-worker.js` file, reload the page

1. From the **Application** > **Service Workers** panel, click the **Skip Waiting** link to allow the new SW to `activate` triggering the delete old caches logic

    ![skipwaiting](https://user-images.githubusercontent.com/459757/58755926-af2c5f80-84a2-11e9-8f76-2bb11022b118.gif)

---

- [Trello Card](https://trello.com/c/RHyivosI/47-service-worker-exercise-5-code)