### PR TITLE
Feature: Service worker exercise 5, trim caches

### DIFF
--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -69,6 +69,15 @@ const isMustHaveAsset = pathname => PRECACHE_ASSETS.MUST_HAVE.includes(pathname)
 
 /**
  * Helper function to trim the cache
+ * 
+ * The trim logic is restricted by the following rules:
+ * - the cached `Request` must be for an image
+ * - the cached `Request` must not be listed in the 
+ *   `PRECACHE_ASSETS.MUST_HAVE` list
+ * - the `MAX_CACHED_ITEMS` constant sets the maximum amount 
+ *   of cached `Request` objects to store
+ * - least recently cached `Request` objects are deleted first,
+ *   this is the default order when calling `cache.keys()`
  */
 const trimCache = async () => {
   console.group('Service Worker trimming caches');

--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -19,7 +19,7 @@ const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|svg|webp)$/;
 /**
  * The maximum amount of cached responses to store
  */
-const MAX_CACHED_ITEMS = 4;
+const MAX_CACHED_ITEMS = 30;
 
 /**
  * The list of assets to precache
@@ -103,6 +103,9 @@ const trimCache = async () => {
     console.log('Deleting:', cachedRequest.url);
     return cache.delete(cachedRequest);
   }));
+  if (!cachedRequestsToDelete.length) {
+    console.log('No caches were trimmed');
+  }
   console.groupEnd();
 }
 

--- a/exercises/service-worker.exercise-5.js
+++ b/exercises/service-worker.exercise-5.js
@@ -12,6 +12,16 @@ const PWA_WORKSHOP_PREFIX = 'pwa-workshop-v';
 const PWA_WORKSHOP_CACHE = `${PWA_WORKSHOP_PREFIX}${VERSION}`;
 
 /**
+ * Regular expression to help detect images
+ */
+const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|svg|webp)$/;
+
+/**
+ * The maximum amount of cached responses to store
+ */
+const MAX_CACHED_ITEMS = 4;
+
+/**
  * The list of assets to precache
  * 
  * `MUST_HAVE`: The service worker will not complete install if 
@@ -36,6 +46,56 @@ const PRECACHE_ASSETS = {
     '/images/sky-friendly-robot.svg'
   ]
 };
+
+/**
+ * ------------------
+ * Utility functions
+ * ------------------
+ */
+
+/**
+ * Helper to know if the request is an image request
+ * @param {Object} request The event request object
+ * @returns {boolean} Is the request an image request?
+ */
+const isImageRequest = request => IMAGE_REGEX.test(request.url);
+
+/**
+ * Helper to check if a pathname is found in the "must have" precache list
+ * @param {string} pathname An asset pathname (e.g. `/images/foo.png`)
+ * @returns {boolean}
+ */
+const isMustHaveAsset = pathname => PRECACHE_ASSETS.MUST_HAVE.includes(pathname);
+
+/**
+ * Helper function to trim the cache
+ */
+const trimCache = async () => {
+  console.group('Service Worker trimming caches');
+  const cache = await caches.open(PWA_WORKSHOP_CACHE);
+  // Get all cached Requests
+  const cachedRequests = await cache.keys();
+  // Any cached Requests in the `cachedRequests` array with an `index`
+  // higher than the `minimumKeepIndex` should not be deleted. Helps
+  // enforce the `MAX_CACHED_ITEMS` total limit.
+  const minimumKeepIndex = cachedRequests.length - MAX_CACHED_ITEMS;
+  // Store the cached requests that should be deleted
+  const cachedRequestsToDelete = cachedRequests
+    .filter((cachedRequest, index) => {
+      // Don't delete "must have" assets from the precache list
+      return !isMustHaveAsset(new URL(cachedRequest.url).pathname)
+        // Only delete images
+        && isImageRequest(cachedRequest)
+        // The `index` should not be in the "keep" range
+        && index < minimumKeepIndex;
+    });
+  // We await an array of `cache.delete()` promises until they are all resolved
+  await Promise.all(cachedRequestsToDelete.map(cachedRequest => {
+    console.log('Deleting:', cachedRequest.url);
+    return cache.delete(cachedRequest);
+  }));
+  console.groupEnd();
+}
 
 /**
  * ---------------------------
@@ -106,6 +166,19 @@ const cacheFallingBackToNetwork = async fetchEvent => {
  * Service worker event listeners & handlers
  * ------------------------------------------
  */
+
+/**
+ * Listen for the `message` event
+ *
+ * The Document and service worker can communicate with
+ * each other through the `postMessage()` API
+ */
+self.addEventListener('message', messageEvent => {
+  // Check the received `action` value from the Document
+  if (messageEvent.data.action === 'trimCache') {
+    trimCache();
+  }
+});
 
 /**
  * Listen for the `install` event

--- a/page-1.html
+++ b/page-1.html
@@ -213,6 +213,9 @@
               <img class="u-block u-sizeFull" src="/images/homework.svg" alt="Illustration of printed work wrapped in markup">
             </div>
             <p>This is page 1. Some text can go here.</p>
+            <div class="u-pullSides1">
+              <img class="u-block u-sizeFull" src="/images/see-no-evil-1.svg" alt="Illustration of printed work wrapped in markup">
+            </div>
           </div>
 
           <!-- TODO: Figure out what to do with the footer??? What content should go here? -->

--- a/page-2.html
+++ b/page-2.html
@@ -209,6 +209,9 @@
           </header>
 
           <div class="CmsContent u-staggerItems1 u-cf">
+            <div class="u-pullSides1">
+              <img class="u-block u-sizeFull" src="/images/aba-progressive-web-apps.jpg" alt="Illustration of printed work wrapped in markup">
+            </div>
             <p>This is page 2.</p>
           </div>
 

--- a/scripts/register-service-worker.js
+++ b/scripts/register-service-worker.js
@@ -12,6 +12,14 @@ if ('serviceWorker' in navigator) {
         // Service worker registration failed. :(
         console.error('Service worker registration failed:', error);
       });
+    
+    // If the page has an active service worker, then send 
+    // a message to trim the caches using the `postMessage()` API
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({
+        'action': 'trimCache'
+      });
+    }
   });
 } else {
   // Service workers are not supported by the browser

--- a/service-worker.js
+++ b/service-worker.js
@@ -69,6 +69,15 @@ const isMustHaveAsset = pathname => PRECACHE_ASSETS.MUST_HAVE.includes(pathname)
 
 /**
  * Helper function to trim the cache
+ * 
+ * The trim logic is restricted by the following rules:
+ * - the cached `Request` must be for an image
+ * - the cached `Request` must not be listed in the 
+ *   `PRECACHE_ASSETS.MUST_HAVE` list
+ * - the `MAX_CACHED_ITEMS` constant sets the maximum amount 
+ *   of cached `Request` objects to store
+ * - least recently cached `Request` objects are deleted first,
+ *   this is the default order when calling `cache.keys()`
  */
 const trimCache = async () => {
   console.group('Service Worker trimming caches');

--- a/service-worker.js
+++ b/service-worker.js
@@ -19,7 +19,7 @@ const IMAGE_REGEX = /\.(?:png|gif|jpg|jpeg|svg|webp)$/;
 /**
  * The maximum amount of cached responses to store
  */
-const MAX_CACHED_ITEMS = 4;
+const MAX_CACHED_ITEMS = 30;
 
 /**
  * The list of assets to precache
@@ -103,6 +103,9 @@ const trimCache = async () => {
     console.log('Deleting:', cachedRequest.url);
     return cache.delete(cachedRequest);
   }));
+  if (!cachedRequestsToDelete.length) {
+    console.log('No caches were trimmed');
+  }
   console.groupEnd();
 }
 


### PR DESCRIPTION
## Overview

This PR introduces the service worker logic to trim caches on the page `load` event. The trim logic is restricted by the following rules:
- the cached `Request` must be for an image
- the cached `Request` must not be listed in the `PRECACHE_ASSETS.MUST_HAVE` list
- a `MAX_CACHED_ITEMS` value sets the maximum amount of cached `Request` objects to store
- least recently cached `Request` objects are deleted first, this is the default order when calling `cache.keys()` (I did not find a way to control this order, nothing to sort by)

## Screenshots

The image below shows an example of what you should see if you load up the Netlify preview: https://deploy-preview-20--festive-keller-9a29cb.netlify.com/

![Screen Shot 2019-06-02 at 2 24 51 PM](https://user-images.githubusercontent.com/459757/58769254-1a853880-855a-11e9-9977-75e4558f63f5.png)

## Testing

1. Checkout this branch:
    ```
    git checkout feature/exercise-5/trim-caches
    ```

1. In the `/service-worker.js` file, change the `MAX_CACHED_ITEMS` value to `4`:
    ```js
    const MAX_CACHED_ITEMS = 4;
    ```

1. Start your local server:
    ```
    python -m SimpleHTTPServer
    ```

1. Open an incognito Chrome browser window and load up http://localhost:8000/page-1.html

1. There should be 3 images in the `pwa-workshop` cache on first page load (precached images)

    <img width="979" alt="Screen Shot 2019-06-02 at 5 23 17 PM" src="https://user-images.githubusercontent.com/459757/58769367-3a692c00-855b-11e9-898c-a01932cb6143.png">

1. Refresh the page, more images will be cached by the SW _but_ once the page `load` fires, the SW will go back and delete images from the cache abiding by the max limit set

    <img width="981" alt="Screen Shot 2019-06-02 at 5 26 22 PM" src="https://user-images.githubusercontent.com/459757/58769420-d6933300-855b-11e9-8adf-1334f0a1ebca.png">

1. Navigate between **Page 1**, **Page 2** and **Page 3** paying attention to the number of image Response objects in the `pwa-workshop` cache, it should be four most times (sometimes it is 5 because the `fallback.svg` image is not counted as one of the 4)

1. Confirm that while navigating between pages, the `/images/fallback.svg` Response object _never_ gets deleted. There is logic in place to never delete anything in the `PRECACHE_ASSETS.MUST_HAVE` list.

1. Flipping to the **Network** tab while keeping the console open, you can see that the files listed by the cache trimming function are going to be the files that get loaded via a network request the next page load (refresh) of the same page

    - Note the `homework.svg` and `portland.svg` response objects were deleted on this page load

        ![Screen Shot 2019-06-02 at 2 27 44 PM](https://user-images.githubusercontent.com/459757/58769524-bb74f300-855c-11e9-8256-0a0bef8f495f.png)

    - After a page reload, notice the `homework.svg` and `portland.svg` files are retrieved from the network because they are no longer cached

        ![Screen Shot 2019-06-02 at 2 28 12 PM](https://user-images.githubusercontent.com/459757/58769553-f8d98080-855c-11e9-88ff-0e83ef4ab2d8.png)

---

- [Trello Card](https://trello.com/c/RHyivosI/47-service-worker-exercise-5-code)