### PR TITLE
Chore: Add diff URLs for completed exercises

### DIFF
--- a/exercises/2/README.md
+++ b/exercises/2/README.md
@@ -1,3 +1,20 @@
 # Progressive Web App Workshop, Exercise 2
 
-TODO: Add exercise 2 instructions, goals & resources
+## What you'll learn
+
+- TODO
+
+## TODO
+
+1. Open the `/service-worker.js` JavaScript file
+
+1. TODO
+
+    - See [`exercises/2/service-worker.2.js`](service-worker.2.js) for the completed JavaScript code
+
+
+TODO: Include this diff that compares Ex.1 to Ex. 2: https://www.diffchecker.com/aJ7rE2UO
+
+## Learning Resources
+
+- https://developers.google.com/web/fundamentals/primers/service-workers/

--- a/exercises/3/README.md
+++ b/exercises/3/README.md
@@ -1,3 +1,23 @@
 # Progressive Web App Workshop, Exercise 3
 
 TODO: Add exercise 3 instructions, goals & resources
+
+## What you'll learn
+
+- TODO
+
+## TODO
+
+1. Open the `/service-worker.js` JavaScript file
+
+1. TODO
+
+    - See [`exercises/3/service-worker.3.js`](service-worker.3.js) for the completed JavaScript code
+
+
+TODO: Include this diff that compares Ex.2 to Ex. 3: 
+https://www.diffchecker.com/9NiJReUF
+
+## Learning Resources
+
+- https://developers.google.com/web/fundamentals/primers/service-workers/

--- a/exercises/4/README.md
+++ b/exercises/4/README.md
@@ -1,3 +1,21 @@
 # Progressive Web App Workshop, Exercise 4
 
 TODO: Add exercise 4 instructions, goals & resources
+
+## What you'll learn
+
+- TODO
+
+## TODO
+
+1. Open the `/service-worker.js` JavaScript file
+
+1. TODO
+
+    - See [`exercises/4/service-worker.4.js`](service-worker.4.js) for the completed JavaScript code
+
+TODO: Include this diff that compares Ex.3 to Ex. 4: https://www.diffchecker.com/ZovsLnzi
+
+## Learning Resources
+
+- https://developers.google.com/web/fundamentals/primers/service-workers/

--- a/exercises/5/README.md
+++ b/exercises/5/README.md
@@ -14,7 +14,7 @@ TODO: Add exercise 5 instructions, goals & resources
 
     - See [`exercises/5/service-worker.5.js`](service-worker.5.js) for the completed JavaScript code
 
-TODO: Include this diff that compares Ex.4 to Ex. 5: https://www.diffchecker.com/ChOwBkbe
+TODO: Include this diff that compares Ex.4 to Ex. 5: https://www.diffchecker.com/RU1do9kj
 
 ## Learning Resources
 

--- a/exercises/5/README.md
+++ b/exercises/5/README.md
@@ -1,3 +1,21 @@
 # Progressive Web App Workshop, Exercise 5
 
 TODO: Add exercise 5 instructions, goals & resources
+
+## What you'll learn
+
+- TODO
+
+## TODO
+
+1. Open the `/service-worker.js` JavaScript file
+
+1. TODO
+
+    - See [`exercises/5/service-worker.5.js`](service-worker.5.js) for the completed JavaScript code
+
+TODO: Include this diff that compares Ex.4 to Ex. 5: https://www.diffchecker.com/ChOwBkbe
+
+## Learning Resources
+
+- https://developers.google.com/web/fundamentals/primers/service-workers/


### PR DESCRIPTION
## Overview

This PR adds diff URLs to the exercise READMEs for complete exercises. 

@grigs I ran with https://www.diffchecker.com but realized I didn't compare my options. If you feel this is not a good option, feel free to say so.

## Testing

Review the diffs to make sure they are accurate

- compares Ex.1 to Ex. 2: https://www.diffchecker.com/aJ7rE2UO
- compares Ex.2 to Ex. 3: https://www.diffchecker.com/9NiJReUF
- compares Ex.3 to Ex. 4: https://www.diffchecker.com/ZovsLnzi
- compares Ex.4 to Ex. 5: https://www.diffchecker.com/RU1do9kj

---

- [Trello Card](https://trello.com/c/n9QxWd8K/51-create-online-exercise-diffs-to-reference)