### PR TITLE
Bugfix: Cache trimming logic

### DIFF
--- a/exercises/5/service-worker.5.js
+++ b/exercises/5/service-worker.5.js
@@ -94,7 +94,7 @@ const trimCache = async () => {
       && isImageRequest(cachedRequest)
     )
     // Then enforce the `MAX_CACHED_ITEMS` limit on the 
-    // cached responses array returned from the first filter()
+    // cached responses array returned from the first filter
     .filter((cachedRequest, index, filteredCachedRequests) => 
       index < filteredCachedRequests.length - MAX_CACHED_ITEMS
     );

--- a/exercises/5/service-worker.5.js
+++ b/exercises/5/service-worker.5.js
@@ -84,25 +84,27 @@ const trimCache = async () => {
   const cache = await caches.open(PWA_WORKSHOP_CACHE);
   // Get all cached Requests
   const cachedRequests = await cache.keys();
-  // Any cached Requests in the `cachedRequests` array with an `index`
-  // higher than the `minimumKeepIndex` should not be deleted. Helps
-  // enforce the `MAX_CACHED_ITEMS` total limit.
-  const minimumKeepIndex = cachedRequests.length - MAX_CACHED_ITEMS;
   // Store the cached requests that should be deleted
   const cachedRequestsToDelete = cachedRequests
-    .filter((cachedRequest, index) => {
+    // First filter out cached responses that should not be deleted
+    .filter(cachedRequest => 
       // Don't delete "must have" assets from the precache list
-      return !isMustHaveAsset(new URL(cachedRequest.url).pathname)
-        // Only delete images
-        && isImageRequest(cachedRequest)
-        // The `index` should not be in the "keep" range
-        && index < minimumKeepIndex;
-    });
+      !isMustHaveAsset(new URL(cachedRequest.url).pathname)
+      // Only delete images
+      && isImageRequest(cachedRequest)
+    )
+    // Then enforce the `MAX_CACHED_ITEMS` limit on the 
+    // cached responses array returned from the first filter()
+    .filter((cachedRequest, index, filteredCachedRequests) => 
+      index < filteredCachedRequests.length - MAX_CACHED_ITEMS
+    );
   // We await an array of `cache.delete()` promises until they are all resolved
-  await Promise.all(cachedRequestsToDelete.map(cachedRequest => {
-    console.log('Deleting:', cachedRequest.url);
-    return cache.delete(cachedRequest);
-  }));
+  await Promise.all(
+    cachedRequestsToDelete.map(cachedRequest => {
+      console.log('Deleting:', cachedRequest.url);
+      return cache.delete(cachedRequest);
+    })
+  );
   if (!cachedRequestsToDelete.length) {
     console.log('No caches were trimmed');
   }

--- a/service-worker.js
+++ b/service-worker.js
@@ -119,10 +119,10 @@ const trimCache = async () => {
  * "Cache First" caching strategy
  * 
  * 1. Fetch from the cache
- *    - Return cached response if found
+ *    - Return cached response if found
  * 2. Fallback to fetch from the network
- *    - Store a copy of the network response in the cache
- *    - Return network response
+ *    - Store a copy of the network response in the cache
+ *    - Return network response
  * 
  * @see https://jakearchibald.com/2014/offline-cookbook/#on-network-response
  * @param {FetchEvent} fetchEvent A fetch event object
@@ -151,9 +151,9 @@ const cacheFirst = async fetchEvent => {
  * "Cache, falling back to network" caching strategy
  * 
  * 1. Fetch from the cache
- *    - Return cached response if found
+ *    - Return cached response if found
  * 2. Fallback to fetch from the network
- *    - Return network response
+ *    - Return network response
  * 
  * @see https://jakearchibald.com/2014/offline-cookbook/#cache-falling-back-to-network
  * @param {FetchEvent} fetchEvent A fetch event object
@@ -181,8 +181,8 @@ const cacheFallingBackToNetwork = async fetchEvent => {
 
 /**
  * Listen for the `message` event
- * 
- * The Document and service worker can communicate with 
+ *
+ * The Document and service worker can communicate with
  * each other through the `postMessage()` API
  */
 self.addEventListener('message', messageEvent => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -94,7 +94,7 @@ const trimCache = async () => {
       && isImageRequest(cachedRequest)
     )
     // Then enforce the `MAX_CACHED_ITEMS` limit on the 
-    // cached responses array returned from the first filter()
+    // cached responses array returned from the first filter
     .filter((cachedRequest, index, filteredCachedRequests) => 
       index < filteredCachedRequests.length - MAX_CACHED_ITEMS
     );

--- a/service-worker.js
+++ b/service-worker.js
@@ -92,7 +92,7 @@ const trimCache = async () => {
   const cachedRequestsToDelete = cachedRequests
     .filter((cachedRequest, index) => {
       // Don't delete "must have" assets from the precache list
-      return !isMustHaveAsset(new URL(cachedRequest.url).pathname) 
+      return !isMustHaveAsset(new URL(cachedRequest.url).pathname)
         // Only delete images
         && isImageRequest(cachedRequest)
         // The `index` should not be in the "keep" range

--- a/service-worker.js
+++ b/service-worker.js
@@ -84,25 +84,27 @@ const trimCache = async () => {
   const cache = await caches.open(PWA_WORKSHOP_CACHE);
   // Get all cached Requests
   const cachedRequests = await cache.keys();
-  // Any cached Requests in the `cachedRequests` array with an `index`
-  // higher than the `minimumKeepIndex` should not be deleted. Helps
-  // enforce the `MAX_CACHED_ITEMS` total limit.
-  const minimumKeepIndex = cachedRequests.length - MAX_CACHED_ITEMS;
   // Store the cached requests that should be deleted
   const cachedRequestsToDelete = cachedRequests
-    .filter((cachedRequest, index) => {
+    // First filter out cached responses that should not be deleted
+    .filter(cachedRequest => 
       // Don't delete "must have" assets from the precache list
-      return !isMustHaveAsset(new URL(cachedRequest.url).pathname)
-        // Only delete images
-        && isImageRequest(cachedRequest)
-        // The `index` should not be in the "keep" range
-        && index < minimumKeepIndex;
-    });
+      !isMustHaveAsset(new URL(cachedRequest.url).pathname)
+      // Only delete images
+      && isImageRequest(cachedRequest)
+    )
+    // Then enforce the `MAX_CACHED_ITEMS` limit on the 
+    // cached responses array returned from the first filter()
+    .filter((cachedRequest, index, filteredCachedRequests) => 
+      index < filteredCachedRequests.length - MAX_CACHED_ITEMS
+    );
   // We await an array of `cache.delete()` promises until they are all resolved
-  await Promise.all(cachedRequestsToDelete.map(cachedRequest => {
-    console.log('Deleting:', cachedRequest.url);
-    return cache.delete(cachedRequest);
-  }));
+  await Promise.all(
+    cachedRequestsToDelete.map(cachedRequest => {
+      console.log('Deleting:', cachedRequest.url);
+      return cache.delete(cachedRequest);
+    })
+  );
   if (!cachedRequestsToDelete.length) {
     console.log('No caches were trimmed');
   }


### PR DESCRIPTION
## Overview

This PR fixes a bug that @grigs found with the `trimCache()` logic.

The updated logic now waits to receive the filtered list first before running the `index` logic when referencing the `MAX_CACHED_ITEMS`. 

## Screenshots

![Screen Shot 2019-06-06 at 12 51 41 PM](https://user-images.githubusercontent.com/459757/59006189-a0a3c680-885b-11e9-828a-9869786129d1.png)
![Screen Shot 2019-06-06 at 12 52 02 PM](https://user-images.githubusercontent.com/459757/59006190-a13c5d00-885b-11e9-913a-88a264b68379.png)
![Screen Shot 2019-06-06 at 12 52 12 PM](https://user-images.githubusercontent.com/459757/59006191-a13c5d00-885b-11e9-9d1b-5f89b5db6b06.png)


## Testing

1. Checkout this branch:
    ```
    git checkout bugfix/trim-cache-logic
    ```

1. In the `/service-worker.js` file, change the `MAX_CACHED_ITEMS` value to `5`:
    ```js
    const MAX_CACHED_ITEMS = 5;
    ```

1. Start your local via **Web Server for Chrome**

1. Open an incognito Chrome browser window and load up http://localhost:8887

1. Navigate between pages paying attention to the number of image Response objects in the `pwa-workshop` cache, it should be five not counting the `fallback.svg` image

1. Confirm that while navigating between pages, the `/images/fallback.svg` Response object _never_ gets deleted

---

- [Trello Card](https://trello.com/c/1B8VxVDV/62-refactor-faulty-trim-cache-logic)